### PR TITLE
Upgrade dependencies

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rust_version: [1.60, stable]
+        rust_version: [1.60.0, stable]
     steps:
       - uses: actions/checkout@master
       - uses: actions-rs/toolchain@v1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rust_version: [1.60.0, stable]
+        rust_version: [1.62.0, stable]
     steps:
       - uses: actions/checkout@master
       - uses: actions-rs/toolchain@v1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rust_version: [1.56, stable]
+        rust_version: [1.60, stable]
     steps:
       - uses: actions/checkout@master
       - uses: actions-rs/toolchain@v1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ keywords = ["kdl", "configuration", "parser"]
 categories = ["parser-implementations", "config", "encoding"]
 homepage = "https://github.com/tailhook/knuffel"
 documentation = "https://docs.rs/knuffel"
-rust-version = "1.60.0"
+rust-version = "1.62.0"
 readme = "README.md"
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,16 +20,16 @@ rust-version = "1.56.0"
 readme = "README.md"
 
 [dependencies]
-chumsky = {version="0.8.0", default-features=false}
-knuffel-derive = {path="./derive", version= "^2.0.0", optional=true}
-base64 = {version="0.13.0", optional=true}
-unicode-width = {version="0.1.9", optional=true}
-minicbor = {version="0.13.2", optional=true, features=["std", "derive"]}
-miette = "4.3.0"
+chumsky = { version = "0.8.0", default-features = false }
+knuffel-derive = { path = "./derive", version = "^2.0.0", optional = true }
+base64 = { version = "0.21.0", optional = true }
+unicode-width = { version = "0.1.9", optional = true }
+minicbor = { version = "0.18.0", optional = true, features = ["std", "derive"] }
+miette = "5.0.0"
 thiserror = "1.0.30"
 
 [dev-dependencies]
-miette = { version="4.3.0", features=["fancy"] }
+miette = { version = "5.0.0", features = ["fancy"] }
 assert-json-diff = "2.0.1"
 serde_json = "1.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ keywords = ["kdl", "configuration", "parser"]
 categories = ["parser-implementations", "config", "encoding"]
 homepage = "https://github.com/tailhook/knuffel"
 documentation = "https://docs.rs/knuffel"
-rust-version = "1.56.0"
+rust-version = "1.60.0"
 readme = "README.md"
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ chumsky = { version = "0.8.0", default-features = false }
 knuffel-derive = { path = "./derive", version = "^2.0.0", optional = true }
 base64 = { version = "0.21.0", optional = true }
 unicode-width = { version = "0.1.9", optional = true }
-minicbor = { version = "0.18.0", optional = true, features = ["std", "derive"] }
+minicbor = { version = "0.19.0", optional = true, features = ["std", "derive"] }
 miette = "5.0.0"
 thiserror = "1.0.30"
 

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -16,11 +16,11 @@ proc_macro = true
 
 [dependencies]
 heck = "0.4.0"
-syn = {version="1.0.81", features=["full", "extra-traits"]}
+syn = { version = "1.0.81", features = ["full", "extra-traits"] }
 quote = "1.0.10"
 proc-macro2 = "1.0.32"
 proc-macro-error = "1.0.4"
 
 [dev-dependencies]
-knuffel = { path=".." }
-miette = { version="4.3.0", features=["fancy"] }
+knuffel = { path = ".." }
+miette = { version = "5.0.0", features = ["fancy"] }

--- a/derive/tests/normal.rs
+++ b/derive/tests/normal.rs
@@ -542,12 +542,12 @@ fn parse_str() {
     assert_eq!(parse_doc::<Parse>(r#"listen "127.0.0.1:8080""#),
                Parse { listen: "127.0.0.1:8080".parse().unwrap() });
     assert_eq!(parse_doc_err::<Parse>(r#"listen "2/3""#),
-        "invalid IP address syntax");
+        "invalid socket address syntax");
 
     assert_eq!(parse::<ParseOpt>(r#"server listen="127.0.0.1:8080""#),
                ParseOpt { listen: Some("127.0.0.1:8080".parse().unwrap()) });
     assert_eq!(parse_err::<ParseOpt>(r#"server listen="2/3""#),
-        "invalid IP address syntax");
+        "invalid socket address syntax");
     assert_eq!(parse::<ParseOpt>(r#"server listen=null"#),
                ParseOpt { listen: None });
 }
@@ -559,7 +559,7 @@ fn parse_bytes() {
     assert_eq!(parse_doc::<Bytes>(r#"data "world""#),
                Bytes { data: b"world".to_vec() });
     assert_eq!(parse_doc_err::<Bytes>(r#"data (base64)"2/3""#),
-        "Invalid last symbol 51, offset 2.");
+        "Invalid padding");
 
     assert_eq!(parse::<OptBytes>(r#"node data=(base64)"aGVsbG8=""#),
                OptBytes { data: Some(b"hello".to_vec()) });

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -293,19 +293,19 @@ mod cbor {
     use minicbor::encode::Encode;
     use minicbor::decode::Decode;
 
-    impl<'d> Decode<'d> for TypeName {
-        fn decode(d: &mut Decoder<'d>)
+    impl<'d, C> Decode<'d, C> for TypeName {
+        fn decode(d: &mut Decoder<'d>, _: &mut C)
             -> Result<Self, minicbor::decode::Error>
         {
             d.str().and_then(|s| s.parse().map_err(|e| match e {}))
         }
     }
-    impl Encode for TypeName {
-        fn encode<W>(&self, e: &mut Encoder<W>)
+    impl<C> Encode<C> for TypeName {
+        fn encode<W>(&self, e: &mut Encoder<W>, ctx: &mut C)
             -> Result<(), minicbor::encode::Error<W::Error>>
             where W: minicbor::encode::write::Write
         {
-            self.as_str().encode(e)
+            self.as_str().encode(e, ctx)
         }
     }
 }

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -6,6 +6,7 @@ use std::collections::HashMap;
 use std::default::Default;
 use std::fmt;
 
+#[cfg(feature="base64")] 
 use base64::{Engine as _, engine::general_purpose::STANDARD};
 
 use crate::ast::{Literal, BuiltinType, Value, SpannedNode};

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -6,6 +6,8 @@ use std::collections::HashMap;
 use std::default::Default;
 use std::fmt;
 
+use base64::{Engine as _, engine::general_purpose::STANDARD};
+
 use crate::ast::{Literal, BuiltinType, Value, SpannedNode};
 use crate::errors::{DecodeError, ExpectedType};
 use crate::traits::{ErrorSpan, Decode};
@@ -53,7 +55,7 @@ pub fn bytes<S: ErrorSpan>(value: &Value<S>, ctx: &mut Context<S>) -> Vec<u8> {
                 #[cfg(feature="base64")] {
                     match &*value.literal {
                         Literal::String(s) => {
-                            match base64::decode(s.as_bytes()) {
+                            match STANDARD.decode(s.as_bytes()) {
                                 Ok(vec) => vec,
                                 Err(e) => {
                                     ctx.emit_error(DecodeError::conversion(

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -20,8 +20,8 @@ use crate::traits::{ErrorSpan, Span};
 /// Implements [`miette::Diagnostic`] so can be used to print nice error
 /// output with code snippets.
 ///
-/// See [crate documentation](crate#Errors) and [miette} documentation to
-/// find out how deal with them.
+/// See [crate documentation](crate#Errors) and [miette] documentation to
+/// find out how to deal with them.
 #[derive(Debug, Diagnostic, Error)]
 #[error("error parsing KDL")]
 pub struct Error {

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -20,8 +20,8 @@ use crate::traits::{ErrorSpan, Span};
 /// Implements [`miette::Diagnostic`] so can be used to print nice error
 /// output with code snippets.
 ///
-/// See [crate documentation](crate#Errors) and [miette] documentation to
-/// find out how to deal with them.
+/// See [crate documentation](crate#Errors) and [miette} documentation to
+/// find out how deal with them.
 #[derive(Debug, Diagnostic, Error)]
 #[error("error parsing KDL")]
 pub struct Error {


### PR DESCRIPTION
- Minimal increments of the specified versions eventually to match up with the latest ones (can be tightened up if preferred).
- Upgrade of the minimal supported Rust version to 1.62.0.
  - Cargo before version 1.60 has an [issue](https://github.com/rust-lang/cargo/issues/10623) to select dependencies when they are using some newer features.
  - The latest `minicbor` 0.19.0 uses a method `then_some` which is [stable since 1.62.0](https://doc.rust-lang.org/std/primitive.bool.html#method.then_some).
- Formatting Cargo.toml (can be reverted if preferred).
- Resolving a deprecation warning from `base64` ([since 0.21.0](https://docs.rs/base64/latest/base64/fn.decode.html)).
- Correct expected error messages in the `normal` test.

# Info

| name | latest | before (Cargo.toml/.lock) | after (Cargo.toml/.lock) |
| - | - | - | - |
| **knuffel** | | | |
| chumsky | 0.8.0 | 0.8.0/0.8.0 ✓ | - |
| base64 | 0.21.0 | 0.13.0/0.13.0 | 0.21.0/0.21.0 ✓ |
| unicode-width | 0.1.10 | 0.1.9/0.1.10 ✓ | - |
| minicbor | 0.19.0 | 0.13.2/0.13.2 | 0.19.0/0.19.0 ✓ |
| miette | 5.5.0 | 4.3.0/4.7.1 | 5.0.0/5.5.0 ✓ |
| thiserror | 1.0.38 | 1.0.30/1.0.38 ✓ | - |
| assert-json-diff | 2.0.2 | 2.0.1/2.0.2 ✓ | - |
| serde_json | 1.0.91 | 1.0/1.0.91 ✓ | - |
| **derive** | | | |
| heck | 0.4.0 | 0.4.0/0.4.0 ✓ | - |
| syn | 1.0.107 | 1.0.81/1.0.107 ✓ | - |
| quote | 1.0.23 | 1.0.10/1.0.23 ✓ | - |
| proc-macro2 | 1.0.50 | 1.0.32/1.0.50 ✓ | - |
| proc-macro-error | 1.0.4 | 1.0.4/1.0.4 ✓ | - |

Closes #12.