### PR TITLE
Add property list (.plist) example

### DIFF
--- a/examples/plist.rs
+++ b/examples/plist.rs
@@ -19,11 +19,10 @@ pub enum Element {
     Data(#[knuffel(argument, bytes)] Vec<u8>),
     Date(#[knuffel(argument, str)] NaiveDateTime),
     Dict(Box<Dict>),
-    Real(#[knuffel(argument)] f32),
-    Integer(#[knuffel(argument)] i32),
-    String(#[knuffel(argument)] String),
-    True,
-    False
+    Real(#[knuffel(argument, default)] f32),
+    Integer(#[knuffel(argument, default)] i32),
+    String(#[knuffel(argument, default)] String),
+    Bool(#[knuffel(argument)] bool)
 }
 
 #[derive(Debug, Decode)]

--- a/examples/plist.rs
+++ b/examples/plist.rs
@@ -19,7 +19,7 @@ pub enum Element {
     Data(#[knuffel(argument, bytes)] Vec<u8>),
     Date(#[knuffel(argument, str)] NaiveDateTime),
     Dict(Box<Dict>),
-    Real(#[knuffel(argument)] i32),  // TODO f32
+    Real(#[knuffel(argument)] f32),
     Integer(#[knuffel(argument)] i32),
     String(#[knuffel(argument)] String),
     True,

--- a/examples/plist.rs
+++ b/examples/plist.rs
@@ -1,0 +1,38 @@
+/*!
+<https://www.apple.com/DTDs/PropertyList-1.0.dtd>
+*/
+
+use chrono::NaiveDateTime;
+use knuffel::Decode;
+
+#[derive(Debug, Decode)]
+pub struct PList {
+    #[knuffel(property)]
+    version: String,
+    #[knuffel(children)]
+    elements: Vec<Element>
+}
+
+#[derive(Debug, Decode)]
+pub enum Element {
+    Array(#[knuffel(children)] Vec<Box<Element>>),
+    Data(#[knuffel(argument, bytes)] Vec<u8>),
+    Date(#[knuffel(argument, str)] NaiveDateTime),
+    Dict(Box<Dict>),
+    Real(#[knuffel(argument)] i32),  // TODO f32
+    Integer(#[knuffel(argument)] i32),
+    String(#[knuffel(argument)] String),
+    True,
+    False
+}
+
+#[derive(Debug, Decode)]
+pub struct Dict {
+    #[knuffel(children(name = "key"))]
+    keys: Vec<Key>,
+    #[knuffel(children)]
+    values: Vec<Element>
+}
+
+#[derive(Debug, Decode)]
+pub struct Key(#[knuffel(argument)] String);


### PR DESCRIPTION
Here is my code donation and the knuffel implementation of [Property List](https://en.wikipedia.org/wiki/Property_list) (.plist) in KDL.

Please merge https://github.com/tailhook/knuffel/pull/21 fist, as this example contains a novel decimal case (`f32`).