### PR TITLE
Floating point types

### DIFF
--- a/derive/tests/types.rs
+++ b/derive/tests/types.rs
@@ -11,6 +11,8 @@ struct Scalars {
     #[knuffel(child, unwrap(argument))]
     u64: u64,
     #[knuffel(child, unwrap(argument))]
+    f64: f64,
+    #[knuffel(child, unwrap(argument))]
     path: PathBuf,
     #[knuffel(child, unwrap(argument))]
     boolean: bool,
@@ -27,12 +29,14 @@ fn parse_enum() {
         parse::<Scalars>(r#"
             str "hello"
             u64 1234
+            f64 1.234
             path "/hello/world"
             boolean true
         "#),
         Scalars {
             str: "hello".into(),
             u64: 1234,
+            f64: 1.234
             path: PathBuf::from("/hello/world"),
             boolean: true,
         });

--- a/derive/tests/types.rs
+++ b/derive/tests/types.rs
@@ -36,7 +36,7 @@ fn parse_enum() {
         Scalars {
             str: "hello".into(),
             u64: 1234,
-            f64: 1.234
+            f64: 1.234,
             path: PathBuf::from("/hello/world"),
             boolean: true,
         });

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -135,6 +135,10 @@ pub enum BuiltinType {
     Usize,
     /// `isize`: platform-dependent signed integer type
     Isize,
+    /// `f32`: 32-bit floating point type
+    F32,
+    /// `f64`: 64-bit floating point type
+    F64,
     /// `base64` denotes binary bytes type encoded using base64 encoding
     Base64,
 }
@@ -198,6 +202,8 @@ impl BuiltinType {
             I64 => "i64",
             Usize => "usize",
             Isize => "isize",
+            F32 => "f32",
+            F64 => "f64",
             Base64 => "base64",
         }
     }
@@ -250,6 +256,8 @@ impl FromStr for BuiltinType {
             "i32" => Ok(I32),
             "u64" => Ok(U64),
             "i64" => Ok(I64),
+            "f32" => Ok(F32),
+            "f64" => Ok(F64),
             "base64" => Ok(Base64),
             _ => Err(())
         }

--- a/src/convert.rs
+++ b/src/convert.rs
@@ -37,7 +37,7 @@ macro_rules! impl_integer {
                                 Ok(0)
                             }
                         }
-                    },
+                    }
                     _ => {
                         ctx.emit_error(DecodeError::scalar_kind(
                                 Kind::String, val));
@@ -106,7 +106,7 @@ macro_rules! impl_decimal {
                                 Ok(0.0)
                             }
                         }
-                    },
+                    }
                     Literal::Decimal(ref value) => {
                         match value.try_into() {
                             Ok(val) => Ok(val),
@@ -115,7 +115,7 @@ macro_rules! impl_decimal {
                                 Ok(0.0)
                             }
                         }
-                    },
+                    }
                     _ => {
                         ctx.emit_error(DecodeError::scalar_kind(
                                 Kind::String, val));


### PR DESCRIPTION
This is a take-over of #6 where the author's request wasn't responded to, that is, keeping `impl_integer` and `impl_decimal` separate for the purpose of clear control flow and readability as prioritised over avoiding a small amount of duplication.

To make the tests pass, please merge https://github.com/tailhook/knuffel/pull/14 first.

Closes #5.