### PR TITLE
Fix "random panic" in DecodeScalar

### DIFF
--- a/src/containers.rs
+++ b/src/containers.rs
@@ -11,7 +11,7 @@ use crate::traits::{ErrorSpan, DecodeSpan, Span};
 
 impl<S: ErrorSpan, T: Decode<S>> Decode<S> for Box<T> {
     fn decode_node(node: &SpannedNode<S>, ctx: &mut Context<S>)
-        -> Result<Self, DecodeError<S>>
+                   -> Result<Self, DecodeError<S>>
     {
         Decode::decode_node(node, ctx).map(Box::new)
     }
@@ -19,7 +19,7 @@ impl<S: ErrorSpan, T: Decode<S>> Decode<S> for Box<T> {
 
 impl<S: ErrorSpan, T: DecodeChildren<S>> DecodeChildren<S> for Box<T> {
     fn decode_children(nodes: &[SpannedNode<S>], ctx: &mut Context<S>)
-        -> Result<Self, DecodeError<S>>
+                       -> Result<Self, DecodeError<S>>
     {
         DecodeChildren::decode_children(nodes, ctx).map(Box::new)
     }
@@ -27,14 +27,14 @@ impl<S: ErrorSpan, T: DecodeChildren<S>> DecodeChildren<S> for Box<T> {
 
 impl<S: ErrorSpan, T: DecodePartial<S>> DecodePartial<S> for Box<T> {
     fn insert_child(&mut self, node: &SpannedNode<S>, ctx: &mut Context<S>)
-        -> Result<bool, DecodeError<S>>
+                    -> Result<bool, DecodeError<S>>
     {
         (**self).insert_child(node, ctx)
     }
     fn insert_property(&mut self,
                        name: &Spanned<Box<str>, S>, value: &Value<S>,
                        ctx: &mut Context<S>)
-        -> Result<bool, DecodeError<S>>
+                       -> Result<bool, DecodeError<S>>
     {
         (**self).insert_property(name, value, ctx)
     }
@@ -46,15 +46,19 @@ impl<S: ErrorSpan, T: DecodeScalar<S>> DecodeScalar<S> for Box<T> {
         T::type_check(type_name, ctx)
     }
     fn raw_decode(value: &Spanned<Literal, S>, ctx: &mut Context<S>)
-        -> Result<Self, DecodeError<S>>
+                  -> Result<Self, DecodeError<S>>
     {
         DecodeScalar::raw_decode(value, ctx).map(Box::new)
+    }
+
+    fn decode(value: &Value<S>, ctx: &mut Context<S>) -> Result<Self, DecodeError<S>> {
+        T::decode(value, ctx).map(Box::new)
     }
 }
 
 impl<S: ErrorSpan, T: Decode<S>> Decode<S> for Arc<T> {
     fn decode_node(node: &SpannedNode<S>, ctx: &mut Context<S>)
-        -> Result<Self, DecodeError<S>>
+                   -> Result<Self, DecodeError<S>>
     {
         Decode::decode_node(node, ctx).map(Arc::new)
     }
@@ -62,7 +66,7 @@ impl<S: ErrorSpan, T: Decode<S>> Decode<S> for Arc<T> {
 
 impl<S: ErrorSpan, T: DecodeChildren<S>> DecodeChildren<S> for Arc<T> {
     fn decode_children(nodes: &[SpannedNode<S>], ctx: &mut Context<S>)
-        -> Result<Self, DecodeError<S>>
+                       -> Result<Self, DecodeError<S>>
     {
         DecodeChildren::decode_children(nodes, ctx).map(Arc::new)
     }
@@ -70,7 +74,7 @@ impl<S: ErrorSpan, T: DecodeChildren<S>> DecodeChildren<S> for Arc<T> {
 
 impl<S: ErrorSpan, T: DecodePartial<S>> DecodePartial<S> for Arc<T> {
     fn insert_child(&mut self, node: &SpannedNode<S>, ctx: &mut Context<S>)
-        -> Result<bool, DecodeError<S>>
+                    -> Result<bool, DecodeError<S>>
     {
         Arc::get_mut(self).expect("no Arc clone yet")
             .insert_child(node, ctx)
@@ -78,7 +82,7 @@ impl<S: ErrorSpan, T: DecodePartial<S>> DecodePartial<S> for Arc<T> {
     fn insert_property(&mut self,
                        name: &Spanned<Box<str>, S>, value: &Value<S>,
                        ctx: &mut Context<S>)
-        -> Result<bool, DecodeError<S>>
+                       -> Result<bool, DecodeError<S>>
     {
         Arc::get_mut(self).expect("no Arc clone yet")
             .insert_property(name, value, ctx)
@@ -92,15 +96,19 @@ impl<S: ErrorSpan, T: DecodeScalar<S>> DecodeScalar<S> for Arc<T> {
         T::type_check(type_name, ctx)
     }
     fn raw_decode(value: &Spanned<Literal, S>, ctx: &mut Context<S>)
-        -> Result<Self, DecodeError<S>>
+                  -> Result<Self, DecodeError<S>>
     {
         DecodeScalar::raw_decode(value, ctx).map(Arc::new)
+    }
+
+    fn decode(value: &Value<S>, ctx: &mut Context<S>) -> Result<Self, DecodeError<S>> {
+        T::decode(value, ctx).map(Arc::new)
     }
 }
 
 impl<S: ErrorSpan, T: Decode<S>> Decode<S> for Rc<T> {
     fn decode_node(node: &SpannedNode<S>, ctx: &mut Context<S>)
-        -> Result<Self, DecodeError<S>>
+                   -> Result<Self, DecodeError<S>>
     {
         Decode::decode_node(node, ctx).map(Rc::new)
     }
@@ -108,7 +116,7 @@ impl<S: ErrorSpan, T: Decode<S>> Decode<S> for Rc<T> {
 
 impl<S: ErrorSpan, T: DecodeChildren<S>> DecodeChildren<S> for Rc<T> {
     fn decode_children(nodes: &[SpannedNode<S>], ctx: &mut Context<S>)
-        -> Result<Self, DecodeError<S>>
+                       -> Result<Self, DecodeError<S>>
     {
         DecodeChildren::decode_children(nodes, ctx).map(Rc::new)
     }
@@ -116,7 +124,7 @@ impl<S: ErrorSpan, T: DecodeChildren<S>> DecodeChildren<S> for Rc<T> {
 
 impl<S: ErrorSpan, T: DecodePartial<S>> DecodePartial<S> for Rc<T> {
     fn insert_child(&mut self, node: &SpannedNode<S>, ctx: &mut Context<S>)
-        -> Result<bool, DecodeError<S>>
+                    -> Result<bool, DecodeError<S>>
     {
         Rc::get_mut(self).expect("no Rc clone yet")
             .insert_child(node, ctx)
@@ -124,7 +132,7 @@ impl<S: ErrorSpan, T: DecodePartial<S>> DecodePartial<S> for Rc<T> {
     fn insert_property(&mut self,
                        name: &Spanned<Box<str>, S>, value: &Value<S>,
                        ctx: &mut Context<S>)
-        -> Result<bool, DecodeError<S>>
+                       -> Result<bool, DecodeError<S>>
     {
         Rc::get_mut(self).expect("no Rc clone yet")
             .insert_property(name, value, ctx)
@@ -138,15 +146,19 @@ impl<S: ErrorSpan, T: DecodeScalar<S>> DecodeScalar<S> for Rc<T> {
         T::type_check(type_name, ctx)
     }
     fn raw_decode(value: &Spanned<Literal, S>, ctx: &mut Context<S>)
-        -> Result<Self, DecodeError<S>>
+                  -> Result<Self, DecodeError<S>>
     {
         DecodeScalar::raw_decode(value, ctx).map(Rc::new)
+    }
+
+    fn decode(value: &Value<S>, ctx: &mut Context<S>) -> Result<Self, DecodeError<S>> {
+        T::decode(value, ctx).map(Rc::new)
     }
 }
 
 impl<S: ErrorSpan, T: Decode<S>> DecodeChildren<S> for Vec<T> {
     fn decode_children(nodes: &[SpannedNode<S>], ctx: &mut Context<S>)
-        -> Result<Self, DecodeError<S>>
+                       -> Result<Self, DecodeError<S>>
     {
         let mut result = Vec::with_capacity(nodes.len());
         for node in nodes {
@@ -165,11 +177,18 @@ impl<S: ErrorSpan, T: DecodeScalar<S>> DecodeScalar<S> for Option<T> {
         T::type_check(type_name, ctx)
     }
     fn raw_decode(value: &Spanned<Literal, S>, ctx: &mut Context<S>)
-        -> Result<Self, DecodeError<S>>
+                  -> Result<Self, DecodeError<S>>
     {
         match &**value {
             Literal::Null => Ok(None),
             _ => DecodeScalar::raw_decode(value, ctx).map(Some),
+        }
+    }
+
+    fn decode(value: &Value<S>, ctx: &mut Context<S>) -> Result<Self, DecodeError<S>> {
+        match &*value.literal {
+            Literal::Null => Ok(None),
+            _ => T::decode(value, ctx).map(Some)
         }
     }
 }
@@ -184,11 +203,19 @@ impl<T: DecodeScalar<S>, S, Q> DecodeScalar<S> for Spanned<T, Q>
         T::type_check(type_name, ctx)
     }
     fn raw_decode(value: &Spanned<Literal, S>, ctx: &mut Context<S>)
-        -> Result<Self, DecodeError<S>>
+                  -> Result<Self, DecodeError<S>>
     {
         let decoded = T::raw_decode(value, ctx)?;
         Ok(Spanned {
             span: DecodeSpan::decode_span(&value.span, ctx),
+            value: decoded,
+        })
+    }
+
+    fn decode(value: &Value<S>, ctx: &mut Context<S>) -> Result<Self, DecodeError<S>> {
+        let decoded = T::decode(value, ctx)?;
+        Ok(Spanned {
+            span: DecodeSpan::decode_span(&value.literal.span, ctx),
             value: decoded,
         })
     }


### PR DESCRIPTION
Currently you can force a panic while decoding a `Value` wrapped in a container because all containers delegate `decode` to the default implementation, while `Value` only accepts calling `decode` directly, 

This PR makes all containers call `::decode` of their child type instead

<details>
<summary>code proof</summary>

```rs
use std::rc::Rc;
use knuffel::ast::Value;
use knuffel::span::Span;

fn main() {
    #[derive(Debug, knuffel::Decode)]
    #[knuffel(span_type = Span)]
    struct X {
        #[knuffel(property)]
        d: Rc<Value<Span>>,
    }

    #[derive(Debug, knuffel::Decode)]
    #[knuffel(span_type = Span)]
    struct Document {
        #[knuffel(child)]
        gamer: X,
    }

    let doc = "gamer d=(uwu)\":3\"";

    let parsed: Document = knuffel::parse("<inline>", doc).unwrap();
    println!("{:?}", parsed);
}
```

</details>

I would also like to note that the trait for `DecodeScalar` seems, confusing?

it's advised not to implement `::decode` by hand, however there's no access to the type name in `::raw_decode`, requiring weird workarounds to implement a polymorphic scalar while also following said advice

I e.g. currently want to support the following:

```kdl
match "literal-match" 
match (re)"regex\smatch"
```
this either requires storing a `MyScalarType` enum in the context, or not following given advice lol