### PR TITLE
Expose `Box<str>` fields of `Integer` and `Decimal`

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -56,18 +56,24 @@ pub struct Document<S> {
     pub nodes: Vec<SpannedNode<S>>,
 }
 
+/// Possible integer radices described by the KDL specification
+#[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature="minicbor", derive(minicbor::Encode, minicbor::Decode))]
 #[cfg_attr(feature="minicbor", cbor(index_only))]
-pub(crate) enum Radix {
+pub enum Radix {
+    /// Binary (Base 2)
     #[cfg_attr(feature="minicbor", n(2))]
     Bin,
-    #[cfg_attr(feature="minicbor", n(16))]
-    Hex,
+    /// Octal (Base 8)
     #[cfg_attr(feature="minicbor", n(8))]
     Oct,
+    /// Decimal (Base 10)
     #[cfg_attr(feature="minicbor", n(10))]
     Dec,
+    /// Hexadecimal (Base 16)
+    #[cfg_attr(feature="minicbor", n(16))]
+    Hex,
 }
 
 /// Potentially unlimited size integer value
@@ -75,9 +81,9 @@ pub(crate) enum Radix {
 #[cfg_attr(feature="minicbor", derive(minicbor::Encode, minicbor::Decode))]
 pub struct Integer(
     #[cfg_attr(feature="minicbor", n(0))]
-    pub(crate) Radix,
+    pub Radix,
     #[cfg_attr(feature="minicbor", n(1))]
-    pub(crate) Box<str>,
+    pub Box<str>,
 );
 
 /// Potentially unlimited precision decimal value
@@ -86,7 +92,7 @@ pub struct Integer(
 #[cfg_attr(feature="minicbor", cbor(transparent))]
 pub struct Decimal(
     #[cfg_attr(feature="minicbor", n(0))]
-    pub(crate) Box<str>,
+    pub Box<str>,
 );
 
 /// Possibly typed KDL scalar value


### PR DESCRIPTION
Hi @tailhook!

Just a simple change exposing a couple of AST fields that were previously only `pub(crate)`. When it came to `Literal::Bool`s and `Literal::String`, their internal fields were already available, but `Decimal` and `Integer` hid their internal string representation. The documentation comment for `Decimal`,  `/// Potentially unlimited precision decimal value`, was very encouraging for me (as I'm working in a scientific domain that absolutely cannot tolerate floating-point errors), but I ran into trouble when trying to write my own `DecodeScalar` implementation for `rust_decimal::Decimal`. With the `Box<str>` representation of `ast::Decimal` exposed, I can now actually write that code. Unless I'm missing something, at the moment the only way to get a value out of `ast::Decimal` is to convert to either an `f32` or `f64`, losing that "potentially unlimited precision". This change lets users decide how to handle that potentially lossy conversion themselves.

The changes to `Integer` aren't things I need directly, but I figured it was worth bringing them in line with `Decimal` for the sake of consistency. The rest of the changes are just adding docstrings to newly-public types.

One thing I'm a bit divided on is the `#[non_exhaustive]` for `Radix`. I just saw that you'd marked `BuiltinType` that way and figured your wanted to allow the spec to add more of these types without it being a breaking change. I don't think anyone really uses any radices other than binary, hex, octal, or decimal in computing, but that's your call on how careful you want to be!

PS. I hope you, your family, and friends are safe amidst the madness in Ukraine at the moment. Hopefully we can get back to fighting over things as inconsequential as code style soon — Слава Україні!