### PR TITLE
Expose `Box<str>` fields of `Integer` and `Decimal`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = [
 ]
 
 [package]
-name = "knuffel"
+name = "knus"
 version = "3.2.0"
 edition = "2021"
 description = """
@@ -14,14 +14,14 @@ description = """
 license = "MIT/Apache-2.0"
 keywords = ["kdl", "configuration", "parser"]
 categories = ["parser-implementations", "config", "encoding"]
-homepage = "https://github.com/tailhook/knuffel"
-documentation = "https://docs.rs/knuffel"
+homepage = "https://github.com/TheLostLambda/knus"
+documentation = "https://docs.rs/knus"
 rust-version = "1.62.0"
 readme = "README.md"
 
 [dependencies]
 chumsky = {version="0.9.2", default-features=false}
-knuffel-derive = {path="./derive", version= "^3.2.0", optional=true}
+knus-derive = {path="./derive", version= "^3.2.0", optional=true}
 base64 = {version="0.21.0", optional=true}
 unicode-width = {version="0.1.9", optional=true}
 minicbor = {version="0.19.1", optional=true, features=["std", "derive"]}
@@ -35,5 +35,5 @@ serde_json = "1.0"
 
 [features]
 default = ["derive", "base64", "line-numbers"]
-derive = ["knuffel-derive"]
+derive = ["knus-derive"]
 line-numbers = ["unicode-width"]

--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,4 +1,4 @@
-Copyright (c) 2021 The knuffel Developers
+Copyright (c) 2021 The knuffel + knus Developers
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -36,30 +36,30 @@ intersections for the arrows)
 
 Most common usage of this library is using `derive` and [parse] function:
 ```rust
-#[derive(knuffel::Decode)]
+#[derive(knus::Decode)]
 enum TopLevelNode {
     Route(Route),
     Plugin(Plugin),
 }
 
-#[derive(knuffel::Decode)]
+#[derive(knus::Decode)]
 struct Route {
-    #[knuffel(argument)]
+    #[knus(argument)]
     path: String,
-    #[knuffel(children(name="route"))]
+    #[knus(children(name="route"))]
     subroutes: Vec<Route>,
 }
 
-#[derive(knuffel::Decode)]
+#[derive(knus::Decode)]
 struct Plugin {
-    #[knuffel(argument)]
+    #[knus(argument)]
     name: String,
-    #[knuffel(property)]
+    #[knus(property)]
     url: String,
 }
 
 # fn main() -> miette::Result<()> {
-let config = knuffel::parse::<Vec<TopLevelNode>>("example.kdl", r#"
+let config = knus::parse::<Vec<TopLevelNode>>("example.kdl", r#"
     route "/api" {
         route "/api/v1"
     }
@@ -71,13 +71,13 @@ let config = knuffel::parse::<Vec<TopLevelNode>>("example.kdl", r#"
 
 This parses into a vector of nodes as enums `TopLevelNode`, but you also use some node as a root of the document if there is no properties and arguments declared:
 ```rust,ignore
-#[derive(knuffel::Decode)]
+#[derive(knus::Decode)]
 struct Document {
-    #[knuffel(child, unwrap(argument))]
+    #[knus(child, unwrap(argument))]
     version: Option<String>,
-    #[knuffel(children(name="route"))]
+    #[knus(children(name="route"))]
     routes: Vec<Route>,
-    #[knuffel(children(name="plugin"))]
+    #[knus(children(name="plugin"))]
     plugins: Vec<Plugin>,
 }
 
@@ -120,11 +120,11 @@ miette = { version="4.3.0", features=["fancy"] }
 And the error returned from parser should be converted to [miette::Report] and
 printed with debugging handler. The most manual way to do that is:
 ```rust
-# #[derive(knuffel::Decode, Debug)]
+# #[derive(knus::Decode, Debug)]
 # struct Config {}
 # let file_name = "1.kdl";
 # let text = "";
-let config = match knuffel::parse::<Config>(file_name, text) {
+let config = match knus::parse::<Config>(file_name, text) {
     Ok(config) => config,
     Err(e) => {
          println!("{:?}", miette::Report::new(e));
@@ -135,14 +135,14 @@ let config = match knuffel::parse::<Config>(file_name, text) {
 But usually function that returns `miette::Result` is good enough:
 ```rust,no_run
 # use std::fs;
-# #[derive(knuffel::Decode)]
+# #[derive(knus::Decode)]
 # struct Config {}
 use miette::{IntoDiagnostic, Context};
 
 fn parse_config(path: &str) -> miette::Result<Config> {
     let text = fs::read_to_string(path).into_diagnostic()
         .wrap_err_with(|| format!("cannot read {:?}", path))?;
-    Ok(knuffel::parse(path, &text)?)
+    Ok(knus::parse(path, &text)?)
 }
 fn main() -> miette::Result<()> {
     let config = parse_config("my.kdl")?;

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
-name = "knuffel-derive"
+name = "knus-derive"
 version = "3.2.0"
 edition = "2021"
 description = """
-    A derive implementation for knuffel KDL parser
+    A derive implementation for knus KDL parser
 """
 license = "MIT/Apache-2.0"
 keywords = ["kdl", "configuration"]
-homepage = "https://github.com/tailhook/knuffel"
-documentation = "https://docs.rs/knuffel"
+homepage = "https://github.com/TheLostLambda/knus"
+documentation = "https://docs.rs/knus"
 readme = "README.md"
 
 [lib]
@@ -22,5 +22,5 @@ proc-macro2 = "1.0.32"
 proc-macro-error = "1.0.4"
 
 [dev-dependencies]
-knuffel = { path=".." }
+knus = { path=".." }
 miette = { version="5.1.1", features=["fancy"] }

--- a/derive/README.md
+++ b/derive/README.md
@@ -1,9 +1,9 @@
 This is derive implementation to make working with [KDL](https://kdl.dev) file
-format convenient that works with [knuffel] parser library.
+format convenient that works with [knus] parser library.
 
-See more in the documentation of [knuffel] library itself.
+See more in the documentation of [knus] library itself.
 
-[knuffel]: https://docs.rs/knuffel
+[knus]: https://docs.rs/knus
 
 
 License

--- a/derive/derive_decode.md
+++ b/derive/derive_decode.md
@@ -1,4 +1,4 @@
-The derive is the most interesting part of the `knuffel` libary.
+The derive is the most interesting part of the `knus` libary.
 
 # Overview
 
@@ -21,15 +21,15 @@ and [children](#children). Unlike in `serde` and similar projects,
 non-annotated fields are not decoded from source and are filled with
 [`std::default::Default`].
 
-All annotations are enclosed by `#[knuffel(..)]` attribute.
+All annotations are enclosed by `#[knus(..)]` attribute.
 
 Both arguments and properties can decode [scalars](#scalars).
 
 If structure only has `child` and `children` fields (see [below](#children)) it
-can be used as a root document (the output of [`knuffel::parse`]). Or root of
+can be used as a root document (the output of [`knus::parse`]). Or root of
 the document can be `Vec<T> where T: Decode`.
 
-[`knuffel::parse`]: fn.parse.html
+[`knus::parse`]: fn.parse.html
 
 Note: node name is usually not used in the structure decoding node, it's
 matched either in parent or in an [enum](#enums).
@@ -53,24 +53,24 @@ node "arg1" true 1 22 333
 ```
 ... can be parsed into the following structure:
 ```rust
-#[derive(knuffel::Decode)]
+#[derive(knus::Decode)]
 struct MyNode {
-    #[knuffel(argument)]
+    #[knus(argument)]
     first: String,
-    #[knuffel(argument)]
+    #[knus(argument)]
     second: bool,
-    #[knuffel(arguments)]
+    #[knus(arguments)]
     numbers: Vec<u32>,
 }
 ```
 
 Arguments can be optional:
 ```rust
-#[derive(knuffel::Decode)]
+#[derive(knus::Decode)]
 struct MyNode {
-    #[knuffel(argument)]
+    #[knus(argument)]
     first: Option<String>,
-    #[knuffel(argument)]
+    #[knus(argument)]
     second: Option<bool>,
 }
 ```
@@ -88,11 +88,11 @@ Note: due to limitations of the procedural macros in Rust, optional arguments
 must use `Option` in this specific notation. Other variations like these:
 ```
 use std::option::Option as Opt;
-#[derive(knuffel::Decode)]
+#[derive(knus::Decode)]
 struct MyNode {
-    #[knuffel(argument)]
+    #[knus(argument)]
     first: ::std::option::Option<String>,
-    #[knuffel(argument)]
+    #[knus(argument)]
     second: Opt<bool>,
 }
 ```
@@ -125,24 +125,24 @@ node name="arg1" enabled=true a=1 b=2 c=3
 Can be parsed into the following structure:
 ```rust
 # use std::collections::HashMap;
-#[derive(knuffel::Decode)]
+#[derive(knus::Decode)]
 struct MyNode {
-    #[knuffel(property)]
+    #[knus(property)]
     name: String,
-    #[knuffel(property)]
+    #[knus(property)]
     enabled: bool,
-    #[knuffel(properties)]
+    #[knus(properties)]
     numbers: HashMap<String, u32>,
 }
 ```
 
 Properties can be optional:
 ```rust
-#[derive(knuffel::Decode)]
+#[derive(knus::Decode)]
 struct MyNode {
-    #[knuffel(property)]
+    #[knus(property)]
     name: Option<String>,
-    #[knuffel(property)]
+    #[knus(property)]
     enabled: Option<bool>,
 }
 ```
@@ -156,11 +156,11 @@ Note: due to limitations of the procedural macros in Rust, optional properties
 must use `Option` in this specific notation. Other variations like this:
 ```rust
 use std::option::Option as Opt;
-#[derive(knuffel::Decode)]
+#[derive(knus::Decode)]
 struct MyNode {
-    #[knuffel(property)]
+    #[knus(property)]
     name: ::std::option::Option<String>,
-    #[knuffel(property)]
+    #[knus(property)]
     enabled: Opt<bool>,
 }
 ```
@@ -169,9 +169,9 @@ Do not work (they will always require `property=null`).
 By default, field name is renamed to use `kebab-case` in KDL file. So field
 defined like this:
 ```rust
-#[derive(knuffel::Decode)]
+#[derive(knus::Decode)]
 struct MyNode {
-    #[knuffel(property)]
+    #[knus(property)]
     plugin_name: String,
 }
 ```
@@ -182,9 +182,9 @@ node plugin-name="my_plugin"
 
 To rename a property in the source use `name=`:
 ```rust
-#[derive(knuffel::Decode)]
+#[derive(knus::Decode)]
 struct MyNode {
-    #[knuffel(property(name="pluginName"))]
+    #[knus(property(name="pluginName"))]
     name: String,
 }
 ```
@@ -208,13 +208,13 @@ All of them work on [properties](#properties) and [arguments](#arguments).
 ## Parsing Strings
 
 The `str` marker is very useful for types coming from other libraries that
-aren't supported by `knuffel` directly.
+aren't supported by `knus` directly.
 
 For example:
 ```rust
-#[derive(knuffel::Decode)]
+#[derive(knus::Decode)]
 struct Server {
-    #[knuffel(property, str)]
+    #[knus(property, str)]
     listen: std::net::SocketAddr,
 }
 ```
@@ -231,9 +231,9 @@ as byte buffer.
 
 For example:
 ```rust
-#[derive(knuffel::Decode)]
+#[derive(knus::Decode)]
 struct Response {
-    #[knuffel(argument, bytes)]
+    #[knus(argument, bytes)]
     body: Vec<u8>,
 }
 ```
@@ -289,21 +289,21 @@ node {
 ```
 ... can be parsed by into the following structures:
 ```rust
-#[derive(knuffel::Decode)]
+#[derive(knus::Decode)]
 enum Setting {
-    Plugin(#[knuffel(argument)] String),
-    Datum(#[knuffel(argument)] String),
+    Plugin(#[knus(argument)] String),
+    Datum(#[knus(argument)] String),
 }
-#[derive(knuffel::Decode)]
+#[derive(knus::Decode)]
 struct Version {
-    #[knuffel(argument)]
+    #[knus(argument)]
     number: u32
 }
-#[derive(knuffel::Decode)]
+#[derive(knus::Decode)]
 struct MyNode {
-    #[knuffel(child)]
+    #[knus(child)]
     version: Version,
-    #[knuffel(children)]
+    #[knus(children)]
     settings: Vec<Setting>
 }
 ```
@@ -311,16 +311,16 @@ struct MyNode {
 There is another form of children which is `children(name="something")`, that
 allows filtering nodes by name:
 ```rust
-#[derive(knuffel::Decode)]
+#[derive(knus::Decode)]
 struct NamedNode {
-    #[knuffel(argument)]
+    #[knus(argument)]
     name: u32
 }
-#[derive(knuffel::Decode)]
+#[derive(knus::Decode)]
 struct MyNode {
-    #[knuffel(children(name="plugin"))]
+    #[knus(children(name="plugin"))]
     plugins: Vec<NamedNode>,
-    #[knuffel(children(name="datum"))]
+    #[knus(children(name="datum"))]
     data: Vec<NamedNode>,
 }
 ```
@@ -342,9 +342,9 @@ plugin "second"
 ```
 ... can be parsed into the list of the following structures:
 ```rust
-#[derive(knuffel::Decode)]
+#[derive(knus::Decode)]
 struct Plugin {
-    #[knuffel(child)]
+    #[knus(child)]
     auto_start: bool,
 }
 ```
@@ -355,7 +355,7 @@ No arguments, properties and children are allowed in the boolean nodes.
 
 Note: due to limitations of the procedural macros in Rust, boolean children
 must use `bool` in this specific notation. If you shadow `bool` type by some
-import the results are undefined (knuffel will still think it's bool node, but
+import the results are undefined (knus will still think it's bool node, but
 it may not work).
 
 
@@ -367,22 +367,22 @@ important role in making document readable.
 
 It works by transforming the following:
 ```rust,ignore
-#[derive(knuffel::Decode)]
+#[derive(knus::Decode)]
 struct Node {
-    #[knuffel(child, unwrap(/* attributes */))]
+    #[knus(child, unwrap(/* attributes */))]
     field: String,
 }
 ```
 ... into something like this:
 ```
-#[derive(knuffel::Decode)]
+#[derive(knus::Decode)]
 struct TmpChild {
-    #[knuffel(/* attributes */)]
+    #[knus(/* attributes */)]
     field: String,
 }
-#[derive(knuffel::Decode)]
+#[derive(knus::Decode)]
 struct Node {
-    #[knuffel(child)]
+    #[knus(child)]
     field: TmpChild,
 }
 ```
@@ -415,11 +415,11 @@ plugin {
 
 Here is the respective Rust structure:
 ```rust
-#[derive(knuffel::Decode)]
+#[derive(knus::Decode)]
 struct Plugin {
-    #[knuffel(child, unwrap(argument))]
+    #[knus(child, unwrap(argument))]
     name: String,
-    #[knuffel(child, unwrap(argument))]
+    #[knus(child, unwrap(argument))]
     url: String,
 }
 ```
@@ -452,13 +452,13 @@ files {
 ```
 This can be parsed into the following structure:
 ```rust
-# #[derive(knuffel::Decode)] struct Plugin {}
-# #[derive(knuffel::Decode)] struct File {}
-#[derive(knuffel::Decode)]
+# #[derive(knus::Decode)] struct Plugin {}
+# #[derive(knus::Decode)] struct File {}
+#[derive(knus::Decode)]
 struct Document {
-    #[knuffel(child, unwrap(children(name="plugin")))]
+    #[knus(child, unwrap(children(name="plugin")))]
     plugins: Vec<Plugin>,
-    #[knuffel(child, unwrap(children(name="file")))]
+    #[knus(child, unwrap(children(name="file")))]
     files: Vec<File>,
 }
 ```
@@ -474,29 +474,29 @@ unmarked ones, can be used as the root of the document.
 
 For example, this structure can:
 ```rust
-# #[derive(knuffel::Decode)]
-# struct NamedNode { #[knuffel(argument)] name: u32 }
-#[derive(knuffel::Decode)]
+# #[derive(knus::Decode)]
+# struct NamedNode { #[knus(argument)] name: u32 }
+#[derive(knus::Decode)]
 struct MyNode {
-    #[knuffel(child, unwrap(argument))]
+    #[knus(child, unwrap(argument))]
     version: u32,
-    #[knuffel(children(name="plugin"))]
+    #[knus(children(name="plugin"))]
     plugins: Vec<NamedNode>,
-    #[knuffel(children(name="datum"))]
+    #[knus(children(name="datum"))]
     data: Vec<NamedNode>,
 }
 ```
 On the other hand this one can **not** because it contains a `property`:
 ```rust
-# #[derive(knuffel::Decode)]
-# struct NamedNode { #[knuffel(argument)] name: u32 }
-#[derive(knuffel::Decode)]
+# #[derive(knus::Decode)]
+# struct NamedNode { #[knus(argument)] name: u32 }
+#[derive(knus::Decode)]
 struct MyNode {
-    #[knuffel(property)]
+    #[knus(property)]
     version: u32,
-    #[knuffel(children(name="plugin"))]
+    #[knus(children(name="plugin"))]
     plugins: Vec<NamedNode>,
-    #[knuffel(children(name="datum"))]
+    #[knus(children(name="datum"))]
     data: Vec<NamedNode>,
 }
 ```
@@ -516,9 +516,9 @@ implemented for the structures that can be used as documents.
 
 There are two forms of it. Marker attribute:
 ```rust
-#[derive(knuffel::Decode)]
+#[derive(knus::Decode)]
 struct MyNode {
-    #[knuffel(property, default)]
+    #[knus(property, default)]
     first: String,
 }
 ```
@@ -527,9 +527,9 @@ filled otherwise (i.e. no such property encountered).
 
 Another form is `default=value`:
 ```rust
-#[derive(knuffel::Decode)]
+#[derive(knus::Decode)]
 struct MyNode {
-    #[knuffel(property, default="unnamed".into())]
+    #[knus(property, default="unnamed".into())]
     name: String,
 }
 ```
@@ -539,9 +539,9 @@ Note, for optional properties `Some` should be included in the default value.
 And for scalar values their value can be overriden by using `null`. The
 definition like this:
 ```rust
-#[derive(knuffel::Decode)]
+#[derive(knus::Decode)]
 struct MyNode {
-    #[knuffel(property, default=Some("unnamed".into()))]
+    #[knus(property, default=Some("unnamed".into()))]
     name: Option<String>,
 }
 ```
@@ -566,18 +566,18 @@ properties or children into another structure.
 
 For example:
 ```rust
-#[derive(knuffel::Decode, Default)]
+#[derive(knus::Decode, Default)]
 struct Common {
-    #[knuffel(child, unwrap(argument))]
+    #[knus(child, unwrap(argument))]
     name: Option<String>,
-    #[knuffel(child, unwrap(argument))]
+    #[knus(child, unwrap(argument))]
     description: Option<String>
 }
-#[derive(knuffel::Decode)]
+#[derive(knus::Decode)]
 struct Plugin {
-    #[knuffel(flatten(child))]
+    #[knus(flatten(child))]
     common: Common,
-    #[knuffel(child, unwrap(argument))]
+    #[knus(child, unwrap(argument))]
     url: String,
 }
 ```
@@ -616,14 +616,14 @@ Here is the example of the node with the type name (the name in parens):
 (text)document name="New Document" { }
 ```
 
-By default knuffel doesn't allow type names for nodes as these are quite rare.
+By default knus doesn't allow type names for nodes as these are quite rare.
 
 To allow type names on specific node and to have the name stored use
 `type_name` attribute:
 ```rust
-#[derive(knuffel::Decode)]
+#[derive(knus::Decode)]
 struct Node {
-    #[knuffel(type_name)]
+    #[knus(type_name)]
     type_name: String,
 }
 ```
@@ -648,22 +648,22 @@ impl std::str::FromStr for PluginType {
     }
 }
 
-#[derive(knuffel::Decode)]
+#[derive(knus::Decode)]
 struct Node {
-    #[knuffel(type_name)]
+    #[knus(type_name)]
     type_name: PluginType,
 }
 ```
 
 ## Node Name
 
-In knuffel, it's common that parent node, document or enum type checks the node name of the node, and node name is not stored or validated in the strucuture.
+In knus, it's common that parent node, document or enum type checks the node name of the node, and node name is not stored or validated in the strucuture.
 
 But for the cases where you need it, it's possible to store too:
 ```rust
-#[derive(knuffel::Decode)]
+#[derive(knus::Decode)]
 struct Node {
-    #[knuffel(node_name)]
+    #[knus(node_name)]
     node_name: String,
 }
 ```
@@ -676,12 +676,12 @@ Node name always exists so optional node_name is not supported.
 
 The following definition:
 ```rust
-use knuffel::span::Span;  // or LineSpan
+use knus::span::Span;  // or LineSpan
 
-#[derive(knuffel::Decode)]
-#[knuffel(span_type=Span)]
+#[derive(knus::Decode)]
+#[knus(span_type=Span)]
 struct Node {
-    #[knuffel(span)]
+    #[knus(span)]
     span: Span,  // This can be user type decoded from Span
 }
 ```
@@ -712,13 +712,13 @@ finish
 ```
 The following enum might be used:
 ```rust
-# #[derive(knuffel::Decode)] struct PrintString {}
-#[derive(knuffel::Decode)]
+# #[derive(knus::Decode)] struct PrintString {}
+#[derive(knus::Decode)]
 enum Action {
-    Create(#[knuffel(argument)] String),
+    Create(#[knus(argument)] String),
     PrintString(PrintString),
     Finish,
-    #[knuffel(skip)]
+    #[knus(skip)]
     InternalAction,
 }
 ```
@@ -750,12 +750,12 @@ implement `DecodeSpan` for any type.
 
 Use use `span_type=` for implemenation of specific type:
 ```rust
-use knuffel::span::Span;  // or LineSpan
+use knus::span::Span;  // or LineSpan
 
-#[derive(knuffel::Decode)]
-#[knuffel(span_type=Span)]
+#[derive(knus::Decode)]
+#[knus(span_type=Span)]
 struct MyStruct {
-    #[knuffel(span)]
+    #[knus(span)]
     span: Span,
 }
 ```

--- a/derive/derive_decode_scalar.md
+++ b/derive/derive_decode_scalar.md
@@ -4,7 +4,7 @@ Currently `DecodeScalar` derive is only implemented for enums
 
 Only enums that contain no data are supported:
 ```rust
-#[derive(knuffel::DecodeScalar)]
+#[derive(knus::DecodeScalar)]
 enum Color {
     Red,
     Blue,
@@ -15,11 +15,11 @@ enum Color {
 
 This will match scalar values in `kebab-case`. For example, this node decoder:
 ```
-# #[derive(knuffel::DecodeScalar)]
+# #[derive(knus::DecodeScalar)]
 # enum Color { Red, Blue, Green, InfraRed }
-#[derive(knuffel::Decode)]
+#[derive(knus::Decode)]
 struct Document {
-    #[knuffel(child, unwrap(arguments))]
+    #[knus(child, unwrap(arguments))]
     all_colors: Vec<Color>,
 }
 ```

--- a/derive/src/definition.rs
+++ b/derive/src/definition.rs
@@ -772,7 +772,7 @@ fn parse_attr_list(attrs: &[syn::Attribute]) -> Vec<(Attr, Span)> {
     let mut all = Vec::new();
     for attr in attrs {
         if matches!(attr.style, syn::AttrStyle::Outer) &&
-            attr.path.is_ident("knuffel")
+            attr.path.is_ident("knus")
 
         {
             match attr.parse_args_with(parse_attrs) {

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -21,7 +21,7 @@ fn emit_decoder(def: &Definition) -> syn::Result<TokenStream> {
 }
 
 #[proc_macro_error::proc_macro_error]
-#[proc_macro_derive(Decode, attributes(knuffel))]
+#[proc_macro_derive(Decode, attributes(knus))]
 #[doc = include_str!("../derive_decode.md")]
 pub fn decode_derive(input: proc_macro::TokenStream)
     -> proc_macro::TokenStream
@@ -34,7 +34,7 @@ pub fn decode_derive(input: proc_macro::TokenStream)
 }
 
 #[proc_macro_error::proc_macro_error]
-#[proc_macro_derive(DecodeScalar, attributes(knuffel))]
+#[proc_macro_derive(DecodeScalar, attributes(knus))]
 #[doc = include_str!("../derive_decode_scalar.md")]
 pub fn decode_scalar_derive(input: proc_macro::TokenStream)
     -> proc_macro::TokenStream

--- a/derive/src/scalar.rs
+++ b/derive/src/scalar.rs
@@ -98,40 +98,40 @@ pub fn emit_enum(e: &Enum) -> syn::Result<TokenStream> {
             quote!(#name => Ok(#e_name::#ident))
         });
     Ok(quote! {
-        impl<S: ::knuffel::traits::ErrorSpan> ::knuffel::DecodeScalar<S>
+        impl<S: ::knus::traits::ErrorSpan> ::knus::DecodeScalar<S>
                 for #e_name {
-            fn raw_decode(val: &::knuffel::span::Spanned<
-                          ::knuffel::ast::Literal, S>,
-                          ctx: &mut ::knuffel::decode::Context<S>)
-                -> Result<#e_name, ::knuffel::errors::DecodeError<S>>
+            fn raw_decode(val: &::knus::span::Spanned<
+                          ::knus::ast::Literal, S>,
+                          ctx: &mut ::knus::decode::Context<S>)
+                -> Result<#e_name, ::knus::errors::DecodeError<S>>
             {
                 match &**val {
-                    ::knuffel::ast::Literal::String(ref s) => {
+                    ::knus::ast::Literal::String(ref s) => {
                         match &s[..] {
                             #(#match_branches,)*
                             _ => {
-                                Err(::knuffel::errors::DecodeError::conversion(
+                                Err(::knus::errors::DecodeError::conversion(
                                         val, #value_err))
                             }
                         }
                     }
                     _ => {
-                        Err(::knuffel::errors::DecodeError::scalar_kind(
-                            ::knuffel::decode::Kind::String,
+                        Err(::knus::errors::DecodeError::scalar_kind(
+                            ::knus::decode::Kind::String,
                             &val,
                         ))
                     }
                 }
             }
-            fn type_check(type_name: &Option<::knuffel::span::Spanned<
-                          ::knuffel::ast::TypeName, S>>,
-                          ctx: &mut ::knuffel::decode::Context<S>)
+            fn type_check(type_name: &Option<::knus::span::Spanned<
+                          ::knus::ast::TypeName, S>>,
+                          ctx: &mut ::knus::decode::Context<S>)
             {
                 if let Some(typ) = type_name {
-                    ctx.emit_error(::knuffel::errors::DecodeError::TypeName {
+                    ctx.emit_error(::knus::errors::DecodeError::TypeName {
                         span: typ.span().clone(),
                         found: Some((**typ).clone()),
-                        expected: ::knuffel::errors::ExpectedType::no_type(),
+                        expected: ::knus::errors::ExpectedType::no_type(),
                         rust_type: stringify!(#e_name),
                     });
                 }

--- a/derive/src/variants.rs
+++ b/derive/src/variants.rs
@@ -29,7 +29,7 @@ pub fn emit_enum(e: &Enum) -> syn::Result<TokenStream> {
         common_generics.params.push(syn::parse2(quote!(S)).unwrap());
         span_ty = quote!(S);
         common_generics.make_where_clause().predicates.push(
-            syn::parse2(quote!(S: ::knuffel::traits::ErrorSpan)).unwrap());
+            syn::parse2(quote!(S: ::knus::traits::ErrorSpan)).unwrap());
     };
     let trait_gen = quote!(<#span_ty>);
     let (impl_gen, _, bounds) = common_generics.split_for_impl();
@@ -42,12 +42,12 @@ pub fn emit_enum(e: &Enum) -> syn::Result<TokenStream> {
 
     let decode = decode(&common, &node)?;
     Ok(quote! {
-        impl #impl_gen ::knuffel::Decode #trait_gen for #name #type_gen
+        impl #impl_gen ::knus::Decode #trait_gen for #name #type_gen
             #bounds
         {
-            fn decode_node(#node: &::knuffel::ast::SpannedNode<#span_ty>,
-                           #ctx: &mut ::knuffel::decode::Context<#span_ty>)
-                -> Result<Self, ::knuffel::errors::DecodeError<#span_ty>>
+            fn decode_node(#node: &::knus::ast::SpannedNode<#span_ty>,
+                           #ctx: &mut ::knus::decode::Context<#span_ty>)
+                -> Result<Self, ::knus::errors::DecodeError<#span_ty>>
             {
                 #decode
             }
@@ -68,13 +68,13 @@ fn decode(e: &Common, node: &syn::Ident) -> syn::Result<TokenStream> {
                     #name => {
                         for arg in &#node.arguments {
                             #ctx.emit_error(
-                                ::knuffel::errors::DecodeError::unexpected(
+                                ::knus::errors::DecodeError::unexpected(
                                     &arg.literal, "argument",
                                     "unexpected argument"));
                         }
                         for (name, _) in &#node.properties {
                             #ctx.emit_error(
-                                ::knuffel::errors::DecodeError::unexpected(
+                                ::knus::errors::DecodeError::unexpected(
                                     name, "property",
                                     format!("unexpected property `{}`",
                                             name.escape_default())));
@@ -82,7 +82,7 @@ fn decode(e: &Common, node: &syn::Ident) -> syn::Result<TokenStream> {
                         if let Some(children) = &#node.children {
                             for child in children.iter() {
                                 #ctx.emit_error(
-                                    ::knuffel::errors::DecodeError::unexpected(
+                                    ::knus::errors::DecodeError::unexpected(
                                         child, "node",
                                         format!("unexpected node `{}`",
                                             child.node_name.escape_default())
@@ -95,7 +95,7 @@ fn decode(e: &Common, node: &syn::Ident) -> syn::Result<TokenStream> {
             }
             VariantKind::Nested { option: false } => {
                 branches.push(quote! {
-                    #name => ::knuffel::Decode::decode_node(#node, #ctx)
+                    #name => ::knus::Decode::decode_node(#node, #ctx)
                         .map(#enum_name::#variant_name),
                 });
             }
@@ -106,7 +106,7 @@ fn decode(e: &Common, node: &syn::Ident) -> syn::Result<TokenStream> {
                             #node.properties.len() > 0 ||
                             #node.children.is_some()
                         {
-                            ::knuffel::Decode::decode_node(#node, #ctx)
+                            ::knus::Decode::decode_node(#node, #ctx)
                                 .map(Some)
                                 .map(#enum_name::#variant_name)
                         } else {
@@ -151,7 +151,7 @@ fn decode(e: &Common, node: &syn::Ident) -> syn::Result<TokenStream> {
         match &**#node.node_name {
             #(#branches)*
             name_str => {
-                Err(::knuffel::errors::DecodeError::conversion(
+                Err(::knus::errors::DecodeError::conversion(
                         &#node.node_name, #err))
             }
         }

--- a/derive/tests/ast.rs
+++ b/derive/tests/ast.rs
@@ -1,15 +1,15 @@
-use knuffel::span::Span;
-use knuffel::traits::Decode;
+use knus::span::Span;
+use knus::traits::Decode;
 
-#[derive(knuffel_derive::Decode, Debug)]
-#[knuffel(span_type=knuffel::span::Span)]
+#[derive(knus_derive::Decode, Debug)]
+#[knus(span_type=knus::span::Span)]
 struct AstChildren {
-    #[knuffel(children)]
-    children: Vec<knuffel::ast::SpannedNode<Span>>,
+    #[knus(children)]
+    children: Vec<knus::ast::SpannedNode<Span>>,
 }
 
 fn parse<T: Decode<Span>>(text: &str) -> T {
-    let mut nodes: Vec<T> = knuffel::parse("<test>", text).unwrap();
+    let mut nodes: Vec<T> = knus::parse("<test>", text).unwrap();
     assert_eq!(nodes.len(), 1);
     nodes.remove(0)
 }

--- a/derive/tests/extra.rs
+++ b/derive/tests/extra.rs
@@ -1,37 +1,37 @@
-use knuffel::span::Span;
-use knuffel::traits::Decode;
-use knuffel::ast::{TypeName, BuiltinType};
+use knus::span::Span;
+use knus::traits::Decode;
+use knus::ast::{TypeName, BuiltinType};
 
-#[derive(knuffel_derive::Decode, Debug, PartialEq)]
+#[derive(knus_derive::Decode, Debug, PartialEq)]
 struct Child;
 
-#[derive(knuffel_derive::Decode, Debug, PartialEq)]
-#[knuffel(span_type=Span)]
+#[derive(knus_derive::Decode, Debug, PartialEq)]
+#[knus(span_type=Span)]
 struct NodeSpan {
-    #[knuffel(span)]
+    #[knus(span)]
     span: Span,
-    #[knuffel(argument)]
+    #[knus(argument)]
     name: String,
-    #[knuffel(children)]
+    #[knus(children)]
     children: Vec<Child>,
 }
 
-#[derive(knuffel_derive::Decode, Debug, PartialEq)]
+#[derive(knus_derive::Decode, Debug, PartialEq)]
 struct NodeType {
-    #[knuffel(type_name)]
+    #[knus(type_name)]
     type_name: String,
 }
 
-#[derive(knuffel_derive::Decode, Debug, PartialEq)]
+#[derive(knus_derive::Decode, Debug, PartialEq)]
 struct NameAndType {
-    #[knuffel(node_name)]
+    #[knus(node_name)]
     node_name: String,
-    #[knuffel(type_name)]
+    #[knus(type_name)]
     type_name: Option<TypeName>,
 }
 
 fn parse<T: Decode<Span>>(text: &str) -> T {
-    let mut nodes: Vec<T> = knuffel::parse("<test>", text).unwrap();
+    let mut nodes: Vec<T> = knus::parse("<test>", text).unwrap();
     assert_eq!(nodes.len(), 1);
     nodes.remove(0)
 }

--- a/derive/tests/flatten.rs
+++ b/derive/tests/flatten.rs
@@ -2,54 +2,54 @@ use std::fmt;
 
 use miette::Diagnostic;
 
-use knuffel::{Decode, span::Span};
-use knuffel::traits::DecodeChildren;
+use knus::{Decode, span::Span};
+use knus::traits::DecodeChildren;
 
 
-#[derive(knuffel_derive::Decode, Default, Debug, PartialEq)]
+#[derive(knus_derive::Decode, Default, Debug, PartialEq)]
 struct Prop1 {
-    #[knuffel(property)]
+    #[knus(property)]
     label: Option<String>,
 }
 
-#[derive(knuffel_derive::Decode, Debug, PartialEq)]
+#[derive(knus_derive::Decode, Debug, PartialEq)]
 struct FlatProp {
-    #[knuffel(flatten(property))]
+    #[knus(flatten(property))]
     props: Prop1,
 }
 
-#[derive(knuffel_derive::Decode, Default, Debug, PartialEq)]
+#[derive(knus_derive::Decode, Default, Debug, PartialEq)]
 struct Unwrap {
-    #[knuffel(child, unwrap(argument))]
+    #[knus(child, unwrap(argument))]
     label: Option<String>,
 }
 
-#[derive(knuffel_derive::Decode, Debug, PartialEq)]
+#[derive(knus_derive::Decode, Debug, PartialEq)]
 struct FlatChild {
-    #[knuffel(flatten(child))]
+    #[knus(flatten(child))]
     children: Unwrap,
 }
 
 
 fn parse<T: Decode<Span>>(text: &str) -> T {
-    let mut nodes: Vec<T> = knuffel::parse("<test>", text).unwrap();
+    let mut nodes: Vec<T> = knus::parse("<test>", text).unwrap();
     assert_eq!(nodes.len(), 1);
     nodes.remove(0)
 }
 
 fn parse_err<T: Decode<Span>+fmt::Debug>(text: &str) -> String {
-    let err = knuffel::parse::<Vec<T>>("<test>", text).unwrap_err();
+    let err = knus::parse::<Vec<T>>("<test>", text).unwrap_err();
     err.related().unwrap()
         .map(|e| e.to_string()).collect::<Vec<_>>()
         .join("\n")
 }
 
 fn parse_doc<T: DecodeChildren<Span>>(text: &str) -> T {
-    knuffel::parse("<test>", text).unwrap()
+    knus::parse("<test>", text).unwrap()
 }
 
 fn parse_doc_err<T: DecodeChildren<Span>+fmt::Debug>(text: &str) -> String {
-    let err = knuffel::parse::<T>("<test>", text).unwrap_err();
+    let err = knus::parse::<T>("<test>", text).unwrap_err();
     err.related().unwrap()
         .map(|e| e.to_string()).collect::<Vec<_>>()
         .join("\n")

--- a/derive/tests/normal.rs
+++ b/derive/tests/normal.rs
@@ -4,219 +4,219 @@ use std::default::Default;
 
 use miette::Diagnostic;
 
-use knuffel::{Decode, span::Span};
-use knuffel::traits::DecodeChildren;
+use knus::{Decode, span::Span};
+use knus::traits::DecodeChildren;
 
 
-#[derive(knuffel_derive::Decode, Debug, PartialEq)]
+#[derive(knus_derive::Decode, Debug, PartialEq)]
 struct Arg1 {
-    #[knuffel(argument)]
+    #[knus(argument)]
     name: String,
 }
 
-#[derive(knuffel_derive::Decode, Debug, PartialEq)]
+#[derive(knus_derive::Decode, Debug, PartialEq)]
 struct Arg1RawIdent {
-    #[knuffel(argument)]
+    #[knus(argument)]
     r#type: String,
 }
 
-#[derive(knuffel_derive::Decode, Debug, PartialEq)]
+#[derive(knus_derive::Decode, Debug, PartialEq)]
 struct ArgDef {
-    #[knuffel(argument, default)]
+    #[knus(argument, default)]
     name: String,
 }
 
-#[derive(knuffel_derive::Decode, Debug, PartialEq)]
+#[derive(knus_derive::Decode, Debug, PartialEq)]
 struct ArgDefValue {
-    #[knuffel(argument, default="unnamed".into())]
+    #[knus(argument, default="unnamed".into())]
     name: String,
 }
 
-#[derive(knuffel_derive::Decode, Debug, PartialEq)]
+#[derive(knus_derive::Decode, Debug, PartialEq)]
 struct ArgDefOptValue {
-    #[knuffel(argument, default=Some("unnamed".into()))]
+    #[knus(argument, default=Some("unnamed".into()))]
     name: Option<String>,
 }
 
-#[derive(knuffel_derive::Decode, Debug, PartialEq)]
+#[derive(knus_derive::Decode, Debug, PartialEq)]
 struct OptArg {
-    #[knuffel(argument)]
+    #[knus(argument)]
     name: Option<String>,
 }
 
-#[derive(knuffel_derive::Decode, Debug, PartialEq)]
+#[derive(knus_derive::Decode, Debug, PartialEq)]
 struct Extra {
     field: String,
 }
 
-#[derive(knuffel_derive::Decode, Debug, PartialEq)]
+#[derive(knus_derive::Decode, Debug, PartialEq)]
 struct VarArg {
-    #[knuffel(arguments)]
+    #[knus(arguments)]
     params: Vec<u64>,
 }
 
-#[derive(knuffel_derive::Decode, Debug, PartialEq, Default)]
+#[derive(knus_derive::Decode, Debug, PartialEq, Default)]
 struct Prop1 {
-    #[knuffel(property)]
+    #[knus(property)]
     label: String,
 }
 
-#[derive(knuffel_derive::Decode, Debug, PartialEq, Default)]
+#[derive(knus_derive::Decode, Debug, PartialEq, Default)]
 struct Prop1RawIdent {
-    #[knuffel(property)]
+    #[knus(property)]
     r#type: String,
 }
 
-#[derive(knuffel_derive::Decode, Debug, PartialEq)]
+#[derive(knus_derive::Decode, Debug, PartialEq)]
 struct PropDef {
-    #[knuffel(property, default)]
+    #[knus(property, default)]
     label: String,
 }
 
-#[derive(knuffel_derive::Decode, Debug, PartialEq)]
+#[derive(knus_derive::Decode, Debug, PartialEq)]
 struct PropDefValue {
-    #[knuffel(property, default="unknown".into())]
+    #[knus(property, default="unknown".into())]
     label: String,
 }
 
-#[derive(knuffel_derive::Decode, Debug, PartialEq)]
+#[derive(knus_derive::Decode, Debug, PartialEq)]
 struct PropDefOptValue {
-    #[knuffel(property, default=Some("unknown".into()))]
+    #[knus(property, default=Some("unknown".into()))]
     label: Option<String>,
 }
 
-#[derive(knuffel_derive::Decode, Debug, PartialEq)]
+#[derive(knus_derive::Decode, Debug, PartialEq)]
 struct PropNamed {
-    #[knuffel(property(name="x"))]
+    #[knus(property(name="x"))]
     label: String,
 }
 
-#[derive(knuffel_derive::Decode, Debug, PartialEq)]
+#[derive(knus_derive::Decode, Debug, PartialEq)]
 struct OptProp {
-    #[knuffel(property)]
+    #[knus(property)]
     label: Option<String>,
 }
 
-#[derive(knuffel_derive::Decode, Debug, PartialEq)]
+#[derive(knus_derive::Decode, Debug, PartialEq)]
 struct VarProp {
-    #[knuffel(properties)]
+    #[knus(properties)]
     scores: BTreeMap<String, u64>,
 }
 
-#[derive(knuffel_derive::Decode, Debug, PartialEq)]
+#[derive(knus_derive::Decode, Debug, PartialEq)]
 struct Children {
-    #[knuffel(children)]
+    #[knus(children)]
     children: Vec<Arg1>,
 }
 
-#[derive(knuffel_derive::Decode, Debug, PartialEq)]
+#[derive(knus_derive::Decode, Debug, PartialEq)]
 struct FilteredChildren {
-    #[knuffel(children(name="left"))]
+    #[knus(children(name="left"))]
     left: Vec<OptArg>,
-    #[knuffel(children(name="right"))]
+    #[knus(children(name="right"))]
     right: Vec<OptArg>,
 }
 
-#[derive(knuffel_derive::Decode, Debug, PartialEq)]
+#[derive(knus_derive::Decode, Debug, PartialEq)]
 enum Variant {
     Arg1(Arg1),
     Prop1(Prop1),
-    #[knuffel(skip)]
+    #[knus(skip)]
     #[allow(dead_code)]
     Var3(u32),
 }
 
-#[derive(knuffel_derive::Decode, Debug, PartialEq)]
+#[derive(knus_derive::Decode, Debug, PartialEq)]
 struct Child {
-    #[knuffel(child)]
+    #[knus(child)]
     main: Prop1,
-    #[knuffel(child)]
+    #[knus(child)]
     extra: Option<Prop1>,
-    #[knuffel(child)]
+    #[knus(child)]
     flag: bool,
-    #[knuffel(child)]
+    #[knus(child)]
     унікод: Option<Prop1>,
 }
 
-#[derive(knuffel_derive::Decode, Debug, PartialEq)]
+#[derive(knus_derive::Decode, Debug, PartialEq)]
 struct ChildDef {
-    #[knuffel(child, default)]
+    #[knus(child, default)]
     main: Prop1,
 }
 
-#[derive(knuffel_derive::Decode, Debug, PartialEq)]
+#[derive(knus_derive::Decode, Debug, PartialEq)]
 struct ChildDefValue {
-    #[knuffel(child, default=Prop1 { label: String::from("prop1") })]
+    #[knus(child, default=Prop1 { label: String::from("prop1") })]
     main: Prop1,
 }
 
-#[derive(knuffel_derive::Decode, Debug, PartialEq)]
+#[derive(knus_derive::Decode, Debug, PartialEq)]
 struct Unwrap {
-    #[knuffel(child, unwrap(argument))]
+    #[knus(child, unwrap(argument))]
     label: String,
 }
 
-#[derive(knuffel_derive::Decode, Debug, PartialEq)]
+#[derive(knus_derive::Decode, Debug, PartialEq)]
 struct UnwrapRawIdent {
-    #[knuffel(child, unwrap(argument))]
+    #[knus(child, unwrap(argument))]
     r#type: String,
 }
 
-#[derive(knuffel_derive::Decode, Debug, PartialEq)]
+#[derive(knus_derive::Decode, Debug, PartialEq)]
 struct UnwrapFiltChildren {
-    #[knuffel(children(name="labels"), unwrap(arguments))]
+    #[knus(children(name="labels"), unwrap(arguments))]
     labels: Vec<Vec<String>>,
 }
 
-#[derive(knuffel_derive::Decode, Debug, PartialEq)]
+#[derive(knus_derive::Decode, Debug, PartialEq)]
 struct UnwrapChildren {
-    #[knuffel(children, unwrap(arguments))]
+    #[knus(children, unwrap(arguments))]
     labels: Vec<Vec<String>>,
 }
 
-#[derive(knuffel_derive::Decode, Debug, PartialEq)]
+#[derive(knus_derive::Decode, Debug, PartialEq)]
 struct Parse {
-    #[knuffel(child, unwrap(argument, str))]
+    #[knus(child, unwrap(argument, str))]
     listen: std::net::SocketAddr,
 }
 
-#[derive(knuffel_derive::Decode, Debug, PartialEq)]
+#[derive(knus_derive::Decode, Debug, PartialEq)]
 struct ParseOpt {
-    #[knuffel(property, str)]
+    #[knus(property, str)]
     listen: Option<std::net::SocketAddr>,
 }
 
-#[derive(knuffel_derive::Decode, Debug, PartialEq)]
+#[derive(knus_derive::Decode, Debug, PartialEq)]
 struct Bytes {
-    #[knuffel(child, unwrap(argument, bytes))]
+    #[knus(child, unwrap(argument, bytes))]
     data: Vec<u8>,
 }
 
-#[derive(knuffel_derive::Decode, Debug, PartialEq)]
+#[derive(knus_derive::Decode, Debug, PartialEq)]
 struct OptBytes {
-    #[knuffel(property, bytes)]
+    #[knus(property, bytes)]
     data: Option<Vec<u8>>,
 }
 
 fn parse<T: Decode<Span>>(text: &str) -> T {
-    let mut nodes: Vec<T> = knuffel::parse("<test>", text).unwrap();
+    let mut nodes: Vec<T> = knus::parse("<test>", text).unwrap();
     assert_eq!(nodes.len(), 1);
     nodes.remove(0)
 }
 
 fn parse_err<T: Decode<Span>+fmt::Debug>(text: &str) -> String {
-    let err = knuffel::parse::<Vec<T>>("<test>", text).unwrap_err();
+    let err = knus::parse::<Vec<T>>("<test>", text).unwrap_err();
     err.related().unwrap()
         .map(|e| e.to_string()).collect::<Vec<_>>()
         .join("\n")
 }
 
 fn parse_doc<T: DecodeChildren<Span>>(text: &str) -> T {
-    knuffel::parse("<test>", text).unwrap()
+    knus::parse("<test>", text).unwrap()
 }
 
 fn parse_doc_err<T: DecodeChildren<Span>+fmt::Debug>(text: &str) -> String {
-    let err = knuffel::parse::<T>("<test>", text).unwrap_err();
+    let err = knus::parse::<T>("<test>", text).unwrap_err();
     err.related().unwrap()
         .map(|e| e.to_string()).collect::<Vec<_>>()
         .join("\n")

--- a/derive/tests/scalar.rs
+++ b/derive/tests/scalar.rs
@@ -1,31 +1,31 @@
 use std::fmt;
 
-use knuffel::{Decode};
-use knuffel::span::Span;
+use knus::{Decode};
+use knus::span::Span;
 use miette::Diagnostic;
 
 
-#[derive(knuffel::DecodeScalar, Debug, PartialEq)]
+#[derive(knus::DecodeScalar, Debug, PartialEq)]
 enum SomeScalar {
     First,
     AnotherOption,
 }
 
-#[derive(knuffel::Decode, Debug, PartialEq)]
+#[derive(knus::Decode, Debug, PartialEq)]
 struct Item {
-    #[knuffel(argument)]
+    #[knus(argument)]
     value: SomeScalar,
 }
 
 
 fn parse<T: Decode<Span>>(text: &str) -> T {
-    let mut nodes: Vec<T> = knuffel::parse("<test>", text).unwrap();
+    let mut nodes: Vec<T> = knus::parse("<test>", text).unwrap();
     assert_eq!(nodes.len(), 1);
     nodes.remove(0)
 }
 
 fn parse_err<T: Decode<Span>+fmt::Debug>(text: &str) -> String {
-    let err = knuffel::parse::<Vec<T>>("<test>", text).unwrap_err();
+    let err = knus::parse::<Vec<T>>("<test>", text).unwrap_err();
     err.related().unwrap()
         .map(|e| e.to_string()).collect::<Vec<_>>()
         .join("\n")

--- a/derive/tests/tuples.rs
+++ b/derive/tests/tuples.rs
@@ -2,38 +2,38 @@ use std::fmt;
 
 use miette::Diagnostic;
 
-use knuffel::{Decode, span::Span};
+use knus::{Decode, span::Span};
 
 
 #[derive(Debug, Decode, PartialEq)]
 struct Unit;
 
 #[derive(Debug, Decode, PartialEq)]
-struct Arg(#[knuffel(argument)] u32);
+struct Arg(#[knus(argument)] u32);
 
 #[derive(Debug, Decode, PartialEq)]
 struct Opt(Option<Arg>);
 
 #[derive(Debug, Decode, PartialEq)]
-struct Extra(#[knuffel(argument)] Option<String>, u32);
+struct Extra(#[knus(argument)] Option<String>, u32);
 
 #[derive(Debug, Decode, PartialEq)]
 enum Enum {
     Unit,
-    Arg(#[knuffel(argument)] u32),
+    Arg(#[knus(argument)] u32),
     Opt(Option<Arg>),
-    Extra(#[knuffel(argument)] Option<String>, u32),
+    Extra(#[knus(argument)] Option<String>, u32),
 }
 
 
 fn parse<T: Decode<Span>>(text: &str) -> T {
-    let mut nodes: Vec<T> = knuffel::parse("<test>", text).unwrap();
+    let mut nodes: Vec<T> = knus::parse("<test>", text).unwrap();
     assert_eq!(nodes.len(), 1);
     nodes.remove(0)
 }
 
 fn parse_err<T: Decode<Span>+fmt::Debug>(text: &str) -> String {
-    let err = knuffel::parse::<Vec<T>>("<test>", text).unwrap_err();
+    let err = knus::parse::<Vec<T>>("<test>", text).unwrap_err();
     err.related().unwrap()
         .map(|e| e.to_string()).collect::<Vec<_>>()
         .join("\n")

--- a/derive/tests/types.rs
+++ b/derive/tests/types.rs
@@ -1,25 +1,25 @@
 use std::path::PathBuf;
 
-use knuffel::{span::Span};
-use knuffel::traits::DecodeChildren;
+use knus::{span::Span};
+use knus::traits::DecodeChildren;
 
 
-#[derive(knuffel_derive::Decode, Debug, PartialEq)]
+#[derive(knus_derive::Decode, Debug, PartialEq)]
 struct Scalars {
-    #[knuffel(child, unwrap(argument))]
+    #[knus(child, unwrap(argument))]
     str: String,
-    #[knuffel(child, unwrap(argument))]
+    #[knus(child, unwrap(argument))]
     u64: u64,
-    #[knuffel(child, unwrap(argument))]
+    #[knus(child, unwrap(argument))]
     f64: f64,
-    #[knuffel(child, unwrap(argument))]
+    #[knus(child, unwrap(argument))]
     path: PathBuf,
-    #[knuffel(child, unwrap(argument))]
+    #[knus(child, unwrap(argument))]
     boolean: bool,
 }
 
 fn parse<T: DecodeChildren<Span>>(text: &str) -> T {
-    knuffel::parse("<test>", text).unwrap()
+    knus::parse("<test>", text).unwrap()
 }
 
 

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -3,23 +3,23 @@ use std::io::Read;
 use miette::IntoDiagnostic;
 
 
-#[derive(knuffel::Decode, Debug)]
+#[derive(knus::Decode, Debug)]
 #[allow(dead_code)]
 struct Plugin {
-    #[knuffel(argument)]
+    #[knus(argument)]
     name: String,
-    #[knuffel(property)]
+    #[knus(property)]
     url: String,
-    #[knuffel(child, unwrap(argument))]
+    #[knus(child, unwrap(argument))]
     version: String,
 }
 
-#[derive(knuffel::Decode, Debug)]
+#[derive(knus::Decode, Debug)]
 #[allow(dead_code)]
 struct Config {
-    #[knuffel(child, unwrap(argument))]
+    #[knus(child, unwrap(argument))]
     version: String,
-    #[knuffel(children(name="plugin"))]
+    #[knus(children(name="plugin"))]
     plugins: Vec<Plugin>,
 }
 
@@ -27,7 +27,7 @@ fn main() -> miette::Result<()> {
     let mut buf = String::new();
     println!("Please type KDL document, press Return, Ctrl+D to finish");
     std::io::stdin().read_to_string(&mut buf).into_diagnostic()?;
-    let cfg: Config = knuffel::parse("<stdin>", &buf)?;
+    let cfg: Config = knus::parse("<stdin>", &buf)?;
     println!("{:#?}", cfg);
     Ok(())
 }

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -56,18 +56,23 @@ pub struct Document<S> {
     pub nodes: Vec<SpannedNode<S>>,
 }
 
+/// Possible integer radices described by the KDL specification
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature="minicbor", derive(minicbor::Encode, minicbor::Decode))]
 #[cfg_attr(feature="minicbor", cbor(index_only))]
-pub(crate) enum Radix {
+pub enum Radix {
+    /// Binary (Base 2)
     #[cfg_attr(feature="minicbor", n(2))]
     Bin,
-    #[cfg_attr(feature="minicbor", n(16))]
-    Hex,
+    /// Octal (Base 8)
     #[cfg_attr(feature="minicbor", n(8))]
     Oct,
+    /// Decimal (Base 10)
     #[cfg_attr(feature="minicbor", n(10))]
     Dec,
+    /// Hexadecimal (Base 16)
+    #[cfg_attr(feature="minicbor", n(16))]
+    Hex,
 }
 
 /// Potentially unlimited size integer value
@@ -75,9 +80,9 @@ pub(crate) enum Radix {
 #[cfg_attr(feature="minicbor", derive(minicbor::Encode, minicbor::Decode))]
 pub struct Integer(
     #[cfg_attr(feature="minicbor", n(0))]
-    pub(crate) Radix,
+    pub Radix,
     #[cfg_attr(feature="minicbor", n(1))]
-    pub(crate) Box<str>,
+    pub Box<str>,
 );
 
 /// Potentially unlimited precision decimal value
@@ -86,7 +91,7 @@ pub struct Integer(
 #[cfg_attr(feature="minicbor", cbor(transparent))]
 pub struct Decimal(
     #[cfg_attr(feature="minicbor", n(0))]
-    pub(crate) Box<str>,
+    pub Box<str>,
 );
 
 /// Possibly typed KDL scalar value
@@ -111,7 +116,9 @@ enum TypeNameInner {
     Custom(Box<str>),
 }
 
-/// Known type identifier described by the KDL specification
+/// Known type identifiers described by the KDL specification — there are more
+/// types defined in the specification than this enum captures, so this enum is
+/// `non_exhaustive` for now.
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum BuiltinType {

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -44,7 +44,7 @@ pub enum Kind {
 
 /// Decodes KDL value as bytes
 ///
-/// Used internally by `#[knuffel(..., bytes)]` attribute. But can be used
+/// Used internally by `#[knus(..., bytes)]` attribute. But can be used
 /// manually for implementing [`DecodeScalar`](crate::traits::DecodeScalar).
 pub fn bytes<S: ErrorSpan>(value: &Value<S>, ctx: &mut Context<S>) -> Vec<u8> {
     if let Some(typ) = &value.type_name {
@@ -103,7 +103,7 @@ pub fn bytes<S: ErrorSpan>(value: &Value<S>, ctx: &mut Context<S>) -> Vec<u8> {
 ///
 /// Flag node is a node that has no arguments, properties or children.
 ///
-/// Used internally by `#[knuffel(child)] x: bool,`. But can be used
+/// Used internally by `#[knus(child)] x: bool,`. But can be used
 /// manually for implementing [`DecodeScalar`](crate::traits::DecodeScalar).
 pub fn check_flag_node<S: ErrorSpan>(
     node: &SpannedNode<S>, ctx: &mut Context<S>)
@@ -173,7 +173,7 @@ impl<S: ErrorSpan> Context<S> {
     }
     /// Set context value
     ///
-    /// These values aren't used by the knuffel itself. But can be used by
+    /// These values aren't used by the knus itself. But can be used by
     /// user-defined decoders to get some value. Each type can have a single but
     /// separate value set. So users are encouraged to use [new type idiom
     /// ](https://doc.rust-lang.org/rust-by-example/generics/new_types.html)

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,6 +1,6 @@
-//! Error types for the knuffel library
+//! Error types for the knus library
 //!
-//! You only need [`Error`](enum@Error) exposed as `knuffel::Error` unless you
+//! You only need [`Error`](enum@Error) exposed as `knus::Error` unless you
 //! do manual implementations of any of the `Decode*` traits.
 use std::borrow::Cow;
 use std::collections::BTreeSet;
@@ -116,7 +116,7 @@ pub enum DecodeError<S: ErrorSpan> {
     /// converted to the Rust value. Including, but not limited to:
     /// 1. Integer value out of range
     /// 2. `FromStr` returned error for the value parse by
-    ///    `#[knuffel(.., str)]`
+    ///    `#[knus(.., str)]`
     #[error("{}", source)]
     #[diagnostic()]
     Conversion {
@@ -141,7 +141,7 @@ pub enum DecodeError<S: ErrorSpan> {
     },
     /// Custom error that can be emitted during decoding
     ///
-    /// This is not used by the knuffel itself. Note most of the time it's
+    /// This is not used by the knus itself. Note most of the time it's
     /// better to use [`DecodeError::Conversion`] as that will associate
     /// source code span to the error.
     #[error(transparent)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@ pub mod span;
 pub mod traits;
 
 #[cfg(feature="derive")]
-pub use knuffel_derive::{Decode, DecodeScalar};
+pub use knus_derive::{Decode, DecodeScalar};
 
 pub use wrappers::{parse_ast, parse, parse_with_context};
 pub use traits::{Decode, DecodeScalar, DecodeChildren};

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -29,8 +29,8 @@ pub trait DecodeChildren<S: ErrorSpan>: Sized {
 /// The trait is implemented for structures that can be used as part of other
 /// structs
 ///
-/// The type of field that `#[knuffel(flatten)]` is used for should implement
-/// this trait. It is automatically implemented by `#[derive(knuffel::Decode)]`
+/// The type of field that `#[knus(flatten)]` is used for should implement
+/// this trait. It is automatically implemented by `#[derive(knus::Decode)]`
 /// by structures that have only optional properties and children (no
 /// arguments).
 pub trait DecodePartial<S: ErrorSpan>: Sized {


### PR DESCRIPTION
Hi @tailhook!

Just a simple change exposing a couple of AST fields that were previously only `pub(crate)`. When it came to `Literal::Bool`s and `Literal::String`, their internal fields were already available, but `Decimal` and `Integer` hid their internal string representation. The documentation comment for `Decimal`,  `/// Potentially unlimited precision decimal value`, was very encouraging for me (as I'm working in a scientific domain that absolutely cannot tolerate floating-point errors), but I ran into trouble when trying to write my own `DecodeScalar` implementation for `rust_decimal::Decimal`. With the `Box<str>` representation of `ast::Decimal` exposed, I can now actually write that code. Unless I'm missing something, at the moment the only way to get a value out of `ast::Decimal` is to convert to either an `f32` or `f64`, losing that "potentially unlimited precision". This change lets users decide how to handle that potentially lossy conversion themselves.

The changes to `Integer` aren't things I need directly, but I figured it was worth bringing them in line with `Decimal` for the sake of consistency. The rest of the changes are just adding docstrings to newly-public types.

One thing I'm a bit divided on is the `#[non_exhaustive]` for `Radix`. I just saw that you'd marked `BuiltinType` that way and figured your wanted to allow the spec to add more of these types without it being a breaking change. I don't think anyone really uses any radices other than binary, hex, octal, or decimal in computing, but that's your call on how careful you want to be!

PS. I hope you, your family, and friends are safe amidst the madness in Ukraine at the moment. Hopefully we can get back to fighting over things as inconsequential as code style soon — Слава Україні!