### PR TITLE
feat(derive): add the `non_empty` attribute to `children(...)`

### DIFF
--- a/derive/src/kw.rs
+++ b/derive/src/kw.rs
@@ -6,6 +6,7 @@ syn::custom_keyword!(children);
 syn::custom_keyword!(default);
 syn::custom_keyword!(flatten);
 syn::custom_keyword!(name);
+syn::custom_keyword!(non_empty);
 syn::custom_keyword!(node_name);
 syn::custom_keyword!(properties);
 syn::custom_keyword!(property);


### PR DESCRIPTION
Hi @tailhook !

This is a slightly bigger change than my other PR, but fundamentally just enables me to add a `non_empty` tag to `#[knuffel(children(...))]` attributes, guaranteeing that at least one child is present. At the moment, Knuffel is happy parsing nodes with no children and simply returning an empty vector, but that's different from the behavior of `#[knuffel(child)]` which (sensibly) errors when no child is present. You can use `child` to parse exactly one child, you can use `children` for zero-or-more, but there is currently no way to parse one-or-more. This PR effectively adds that ability.

I've not written anything up in the documentation just yet (I wanted to be sure you were happy with this feature as is, before writing up anything), but here is a basic example...

Attempting to parse this KDL (with all of the children commented out):
```kdl
  C "Carbon" {
    // isotope 12 12.0000000 0.9893
    // isotope 13 13.00335483507 0.0107
    // isotope 14 14.0032419884
  }
```

Using this struct:
```rust
#[derive(Decode, Debug)]
struct ElementKdl {
    #[knuffel(node_name)]
    symbol: ElementSymbol,
    #[knuffel(argument)]
    name: String,
    #[knuffel(children(name = "isotope", non_empty))]
    isotopes: Vec<IsotopeKdl>,
}
``` 

Now returns an error where it didn't before:
![image](https://github.com/tailhook/knuffel/assets/6251883/3e517391-e432-4ff2-a73a-b33c325bdf34)

Let me know what you think! It's my first time touching proc_macros, so I'm sure there is plenty of learning for me to do!

Hope you're well,
Brooks