### PR TITLE
fix!: prevent double printing of conversion errors

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -117,14 +117,14 @@ pub enum DecodeError<S: ErrorSpan> {
     /// 1. Integer value out of range
     /// 2. `FromStr` returned error for the value parse by
     ///    `#[knuffel(.., str)]`
-    #[error("{}", source)]
+    #[error("{}", error)]
     #[diagnostic()]
     Conversion {
         /// Position of the scalar that could not be converted
         #[label("invalid value")]
         span: S,
         /// Original error
-        source: Box<dyn std::error::Error + Send + Sync + 'static>,
+        error: Box<dyn std::error::Error + Send + Sync + 'static>,
     },
     /// Unsupported value
     ///
@@ -395,7 +395,7 @@ impl<S: ErrorSpan> DecodeError<S> {
     {
         DecodeError::Conversion {
             span: span.span().clone(),
-            source: err.into(),
+            error: err.into(),
         }
     }
     /// Construct [`DecodeError::ScalarKind`] error
@@ -450,8 +450,8 @@ impl<S: ErrorSpan> DecodeError<S> {
             => MissingNode { message },
             Unexpected { span, kind, message }
             => Unexpected { span: f(span), kind, message},
-            Conversion { span, source }
-            => Conversion { span: f(span), source },
+            Conversion { span, error }
+            => Conversion { span: f(span), error },
             Unsupported { span, message }
             => Unsupported { span: f(span), message },
             Custom(e) => Custom(e),


### PR DESCRIPTION
Most of this is just the commit description, but here's a picture of the sort of diff this change produces on my end:
![image](https://github.com/tailhook/knuffel/assets/6251883/d00d58fc-526b-4be1-89e9-ebf958df82f4)
You can see that I used to get the same error message twice (all errors coming from `DecodeError::Conversion` have been doubled!), but now the second, duplicate source line is removed.

Okay, then just the commit description:

Fields named `source` are treated as magical by `thiserror` and, when using `#[derive(Error)]` are assumed to contain a sub-error. When a `DecodeError::Conversion` is then formatted by `miette`, the conversion error message contained in `source` is then printed twice: once by the `#[error("{}", source)]` tag on `DecodeError::Conversion`, then a second time, implicitly, because `miette` believes that
`DecodeError::Conversion` contains an unprinted sub-error.

This change simply renames the `source` field of
`DecodeError::Conversion` to `error`, side-stepping `thiserror`s special treatment of fields named `source`.

BREAKING CHANGE: renamed public field `source` to `error`